### PR TITLE
Add automatic tls cert generation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -87,13 +87,6 @@ RUN git clone https://github.com/gofractally/psibase.git . && \
 ARG DEFAULT_PSINODE_CONFIG=dev.config
 # Set env variables
 ENV PSINODE_PATH=/root/psibase
-## Grafana vars
-ENV GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
-ENV GF_AUTH_ANONYMOUS_ENABLED=true
-ENV GF_AUTH_BASIC_ENABLED=false
-ENV GF_SECURITY_ALLOW_EMBEDDING=true
-ENV GF_SERVER_ROOT_URL=%(protocol)s://%(domain)s:%(http_port)s/grafana/
-ENV GF_SERVER_SERVE_FROM_SUB_PATH=true
 
 # Expose ports
 ## Psinode

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -110,7 +110,6 @@ RUN chmod -R 0700 /usr/local/bin/
 
 # Add configuration files
 RUN mkdir -p $PSINODE_PATH/psinode_db
-ADD psinode/configs $PSINODE_PATH/
 COPY psinode/configs/$DEFAULT_PSINODE_CONFIG $PSINODE_PATH/psinode_db/config
 ADD grok_exporter/patterns /etc/grok_exporter/
 COPY grok_exporter/grok-exporter.yml /root/grok-exporter.yml
@@ -123,3 +122,6 @@ RUN chmod 644 /usr/share/grafana/conf/provisioning/datasources/psinode-datasourc
     chown -R grafana:grafana /usr/share/grafana/conf/provisioning/dashboards/psinode-dashboard.yaml
 ADD grafana/dashboards /var/lib/grafana/dashboards
 COPY grafana/grafana-psinode.ini /etc/grafana/grafana-psinode.ini
+
+# Update path
+ENV PATH=/root/psibase/build/psidk/bin:$PATH

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,14 +1,11 @@
 {
     "name": "${localWorkspaceFolderBasename}",
-    "build": {
-        "dockerfile": "./Dockerfile"
-    },
-    "postCreateCommand": "cp .vscode/c_cpp_properties.json.sample .vscode/c_cpp_properties.json && cp .vscode/tasks.json.sample .vscode/tasks.json",
-    "workspaceMount": "source=${localWorkspaceFolderBasename},target=/root/psibase,type=volume",
+
+    "dockerComposeFile": ["docker-compose.yml"],
+    "service": "psibase",
     "workspaceFolder": "/root/psibase",
-    "mounts": ["type=bind,src=${localWorkspaceFolder}/artifacts,dst=/root/psibase/rust/psibase/boot-image"],
-    "runArgs": ["--name=${localWorkspaceFolderBasename}"],
-    "remoteEnv": { "PATH": "/root/psibase/build/psidk/bin:${containerEnv:PATH}" },
+
+    "postCreateCommand": "cp .vscode/c_cpp_properties.json.sample .vscode/c_cpp_properties.json && cp .vscode/tasks.json.sample .vscode/tasks.json",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -5,6 +5,9 @@ services:
     container_name: psibase-contributor
     ports:
       - 8080:8080
+    environment:
+      - VITE_SECURE_LOCAL_DEV=true
+      - VITE_SECURE_PATH_TO_CERTS=/root/certs/
     volumes:
       - type: volume
         source: psibase-contributor

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,0 +1,36 @@
+version: '3'
+services:
+  psibase:
+    build: .
+    container_name: psibase-contributor
+    ports:
+      - 8080:8080
+    volumes:
+      - type: volume
+        source: psibase-contributor
+        target: /root/psibase
+      - type: bind
+        source: ../artifacts
+        target: /root/psibase/rust/psibase/boot-image
+      - type: bind
+        source: ../local-certs
+        target: /root/certs
+    command: sleep infinity
+  mkcert:
+    image: vishnunair/docker-mkcert:latest
+    container_name: mkcert
+    environment:
+      - domain=psibase.127.0.0.1.sslip.io '*.psibase.127.0.0.1.sslip.io'
+    command: ["/bin/sh", "-c", "mkcert -install && mkcert psibase.127.0.0.1.sslip.io '*.psibase.127.0.0.1.sslip.io' && cp /root/.local/share/mkcert/rootCA.pem /root/.local/share/mkcert/rootCA.pem.crt && tail -f -n0 /etc/hosts"]
+    volumes:
+      - type: bind
+        source: ../local-certs
+        target: /root/.local/share/mkcert
+
+
+volumes:
+  psibase-contributor:
+
+
+# Original from gh
+#command: "mkcert -install && for i in $(echo $domain | sed "s/,/ /g"); do mkcert $i; done && tail -f -n0 /etc/hosts"

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -19,8 +19,6 @@ services:
   mkcert:
     image: vishnunair/docker-mkcert:latest
     container_name: mkcert
-    environment:
-      - domain=psibase.127.0.0.1.sslip.io '*.psibase.127.0.0.1.sslip.io'
     command: ["/bin/sh", "-c", "mkcert -install && mkcert psibase.127.0.0.1.sslip.io '*.psibase.127.0.0.1.sslip.io' && cp /root/.local/share/mkcert/rootCA.pem /root/.local/share/mkcert/rootCA.pem.crt && tail -f -n0 /etc/hosts"]
     volumes:
       - type: bind

--- a/.devcontainer/grafana/grafana-psinode.ini
+++ b/.devcontainer/grafana/grafana-psinode.ini
@@ -1,9 +1,17 @@
+[security]
 allow_embedding=true
 
-#################################### Anonymous Auth ######################
-[auth.anonymous]
-# enable anonymous access
-enabled = true
+[auth.basic]
+enabled = false
 
-# specify role for unauthenticated users
+[auth.anonymous]
+enabled = true
 org_role = Admin
+
+[server]
+root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana/
+serve_from_sub_path = true
+protocol = https
+http_port = 3000
+cert_file = /root/certs/psibase.127.0.0.1.sslip.io+1.pem
+cert_key  = /root/certs/psibase.127.0.0.1.sslip.io+1-key.pem

--- a/.devcontainer/prometheus/prometheus.yml
+++ b/.devcontainer/prometheus/prometheus.yml
@@ -11,7 +11,7 @@ scrape_configs:
     scrape_interval: 1s
     metrics_path: /native/admin/metrics
     static_configs:
-      - targets: ["localhost:8080"]
+      - targets: ["localhost:8079"]
 
   - job_name: "prometheus"
     scrape_interval: 5s

--- a/.devcontainer/psinode/configs/dev.config
+++ b/.devcontainer/psinode/configs/dev.config
@@ -1,5 +1,6 @@
 # psinode configuration
-listen              = 8080
+listen              = https://0.0.0.0:8080
+listen              = http://0.0.0.0:8079
 p2p                 = off
 producer            = myproducer
 host                = psibase.127.0.0.1.sslip.io
@@ -7,6 +8,8 @@ service             = admin-sys.psibase.127.0.0.1.sslip.io:$PREFIX/share/psibase
 service             = localhost:
 admin               = static:*
 database-cache-size = 256MiB
+tls-cert            = /root/certs/psibase.127.0.0.1.sslip.io+1.pem
+tls-key             = /root/certs/psibase.127.0.0.1.sslip.io+1-key.pem
 
 [logger.stderr]
 type   = console

--- a/.devcontainer/run-admin-dashboards.sh
+++ b/.devcontainer/run-admin-dashboards.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 cd /root && prometheus --config.file=/etc/prometheus/prometheus.yml --storage.tsdb.path=/var/lib/prometheus/ --web.console.templates=/etc/prometheus/consoles --web.console.libraries=/etc/prometheus/console_libraries &
-sh -c 'echo '"'"'{"filter":"Severity >= info"}'"'"' | websocat -n ws://localhost:8080/native/admin/log | grok_exporter --config=/root/grok-exporter.yml' &
+sh -c 'echo '"'"'{"filter":"Severity >= info"}'"'"' | websocat -n ws://localhost:8079/native/admin/log | grok_exporter --config=/root/grok-exporter.yml' &
 cd /usr/share/grafana && grafana-server --config /etc/grafana/grafana-psinode.ini &

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This tool is primarily for the developers on the Fractally team, or other develo
 3. Execute the VSCode command to relaunch this repository inside a Docker container <br/> ![Reopen in Container](/img/build-command.png)
 4. Run a full build by clicking the corresponding button in the blue status bar at the bottom of the window in VSCode <br/> ![Execute Build](/img/full-build.png)
 
+## Note on HTTPS
+
+Running psinode using a database with the name "psinode_db" within the container will use the default psinode config file located at `psinode/configs/dev.config`. This is configured to automatically run psinode locally over https. Http is exposed within the container at port 8079, but the 8080 exposed outside the container is https.
+
+Make sure to install the root cert located in this repo at `local-certs/rootCA.pem` (`local-certs/rootCA.pem.crt` for Windows users) to ensure your browser doesn't complain when accessing psinode over https.
+
 ## Workflow loop
 
 In general, your workflow will be to open this psibase contributor repo, relaunch it inside a container, do all develoment activities, commit/push from within the VSCode-integrated bash terminal, close VSCode when finished (this closes the container. All work is saved unless you delete the docker volume).

--- a/local-certs/.gitignore
+++ b/local-certs/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore


### PR DESCRIPTION
This also 
* sets the default configuration file for psinode run with psinode_db to use https.
* sets the default configuration for grafana to use the generated tls certs so it can be served over https

