### PR TITLE
add explicit psibase-contributor image version

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   psibase:
-    image: ghcr.io/gofractally/psibase-contributor:latest
+    image: ghcr.io/gofractally/psibase-contributor:7682e2c5c3522f93dc8bb31e407423fd97d68505
     container_name: psibase-contributor
     ports:
       - 8080:8080

--- a/README.md
+++ b/README.md
@@ -36,20 +36,15 @@ All source code and build files are stored within a named docker volume and are 
 
 ## Updating
 
-Occasionally, updates are made to the Psibase build environment (new external tool/library, etc.) that could cause your Psibase builds to start failing. In order to load the environment changes into your container here, close your connection to the remote development container, and run: `docker pull ghcr.io/gofractally/psibase-contributor:latest` to pull in the latest changes. Then run the command `Rebuild Without Cache and Reopen in Container`:
-![Rebuild Without Cache](/img/rebuild-without-cache.png)
-
-And of course, if there is an update to this tool itself, you may run a standard `git pull` to update the tool, followed by another `Rebuild Without Cache and Reopen in Container`.
+Occasionally, you should use `git pull` in your `psibase-contributor` directory in order to pull the latest changes to the build environment or external tooling. After updating `psibase-contributor`, you should run `Rebuild Without Cache and Reopen in Container` when relaunching your container in order to load the changes into your development environment.
 
 ## Features
 
 The environment in the container set up for you by this tool has many helpful features that simplify the development of Psibase services & applets. Regardless of what VSCode extensions you have locally installed, this development environment is opinionated and will install several VSCode extensions into the container for you. These extensions are for:
 
-1. C++ auto-formatting, refactoring tools, and intellisense (C-mantic, C/C++, Clang-format)
-2. CMake file language support (Cmake)
-3. Showing custom build buttons in the status bar (Command Variable, and Tasks)
-4. Checking git history, blames, diffs, commit IDs, branch diagrams, etc. (GitLens, Open in Github)
-5. Previewing markdown files, with Mermaid diagram support (Markdown Preview Mermaid Support)
+* Language support, auto-formatting, intellisense, refactoring tools (C++, Rust, Javascript, Typescript, Markdown)
+* Showing custom build buttons in the VSCode status bar
+* Version control tools: checking git history, blames, diffs, commit IDs, branch diagrams, etc.
 
 ## Windows troubleshooting
 


### PR DESCRIPTION
The `latest` tag is an antipattern. It's confusing and suboptimal in multiple ways:

1. It makes a user of this tool assume that they should always be pulling the latest image, where in fact they will only actually pull anything the first time they run the tool. To update the image, the user still manually needs to run `docker pull ghcr.io/gofractally/psibase-contributor:latest` in order to pull the latest. 
2. It obfuscates which version of the tool is being used. An explicit commit ID is better because it would let you look at the `image-builders` repo to see exactly which version of the image you're using.

Therefore, this PR changes to using explicit version numbers. 

I intend to eventually delete the `latest` tag from existence.