### PR TITLE
update extensions

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,10 +22,10 @@
                 // cpp
                 "ms-vscode.cpptools",
                 "tdennis4496.cmantic",
-                "xaver.clang-format",
+                "seaube.clangformat",
 
                 // rust
-                "serayuzgur.crates",
+                "fill-labs.dependi",
                 "tamasfe.even-better-toml",
                 "rust-lang.rust-analyzer",
                 "vadimcn.vscode-lldb",


### PR DESCRIPTION
`crates` is deprecated, and `xaver`'s clang-format *should* be deprecated. This PR uses a fork of the original `clang-format` plugin that works better.
