### PR TITLE
Update base image to lock latest base image

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,6 +1,9 @@
 # 0.5
 
+* [Upgrading yarn to Berry (4.9.1)](https://github.com/gofractally/image-builders/pull/60)
 * [Lock cargo-component to v0.20.0 to avoid adapter issues on Apple Silicon](https://github.com/gofractally/image-builders/pull/60)
+* [Fix default config dir](https://github.com/gofractally/image-builders/pull/58)
+* [Add cargo-generate](https://github.com/gofractally/image-builders/commit/54c67673de1b230a5087ad6cfd3eefcfe5160377)
 
 # 0.4
 

--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.5
+
+* [Lock cargo-component to v0.20.0 to avoid adapter issues on Apple Silicon](https://github.com/gofractally/image-builders/pull/60)
+
 # 0.4
 
 * [Remove old dashboard from images](https://github.com/gofractally/image-builders/pull/53)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   psibase:
-    image: ghcr.io/gofractally/psibase-contributor:ecb9e2c0d622d8ee22a224e68b240ea852d4d60f
+    image: ghcr.io/gofractally/psibase-contributor:6965d1130eaca6818cb8c52db86922fb44ce2840
     ports:
       - 8080:8080
     container_name: psibase-contributor
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.4
+      - PSIBASE_CONTRIBUTOR_VERSION=0.5
     volumes:
       - type: volume
         source: psibase-contributor


### PR DESCRIPTION
This avoids the wasm shim problem introduced in cargo-component v0.21.0 that affects Apple Silicon
yarn upgrade
See changelog for full list of changes