### PR TITLE
Updating to version 0.7

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.7
+
+* [Upgrade yarn to v4 and downgrade cargo-component to 0.15.0](https://github.com/gofractally/image-builders/pull/65)
+* [Pin rust at v1.85](https://github.com/gofractally/image-builders/pull/66)
+
 # 0.6
 
 * [Downgrading yarn back to v1.22.22 (classic)](https://github.com/gofractally/image-builders/pull/64)

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   psibase:
-    image: ghcr.io/gofractally/psibase-contributor:13ba0222f0dcd9cf3ea82cc22eaa2004c00f0296
+    image: ghcr.io/gofractally/psibase-contributor:39474caca7611dd4cb884ea952e4a36ec3deac53
     ports:
       - 8080:8080
     container_name: psibase-contributor
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.6
+      - PSIBASE_CONTRIBUTOR_VERSION=0.7
     volumes:
       - type: volume
         source: psibase-contributor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,14 @@
+# Updating versions
+
+Currently, the changelog is managed manually. If you update this tool, you must manually update the changelog with a new version number, and update the `PSIBASE_CONTRIBUTOR_VERSION` environment variable in `.devcontainer/docker-compose.yml`.
+
+# Tag management
+
+To allow people to easily switch between versions, when a PR is merged that contains a new version number, a new tag with the corresponding version number should be pushed. 
+
+For example, these commands were used on `main` to create the `v0.6.0-pre` tag:
+
+```bash
+git tag -a v0.6.0-pre -m "psibase-contributor prerelease version v0.6.0"
+git push origin v0.6.0-pre
+```


### PR DESCRIPTION
Also adds an initial contributing guide with instructions on updating the version number, and pushing a new tag on udpates.