### PR TITLE
remove deprecated extension

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -13,7 +13,6 @@
                 // build
                 "actboy168.tasks",
                 "rioj7.command-variable",
-                "twxs.cmake",
 
                 // web
                 "bradlc.vscode-tailwindcss",


### PR DESCRIPTION
This extension is no longer needed, cmake language server is now part of the `ms-vscode.cmake-tools` extension