### PR TITLE
add clangd extension

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.14
+
+- [Adds clangd extension](https://github.com/gofractally/psibase-contributor/pull/38)
+
 # 0.13
 
 - [Updates to the latest builder image that adds zlib](https://github.com/gofractally/image-builders/pull/72)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
                 "esbenp.prettier-vscode",
 
                 // cpp
-                "ms-vscode.cpptools",
+                "llvm-vs-code-extensions.vscode-clangd",
                 "tdennis4496.cmantic",
                 "seaube.clangformat",
 

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,7 +23,6 @@
                 // cpp
                 "llvm-vs-code-extensions.vscode-clangd",
                 "tdennis4496.cmantic",
-                "seaube.clangformat",
 
                 // rust
                 "fill-labs.dependi",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "workspaceFolder": "/root/psibase",
 
     "initializeCommand": "bash .devcontainer/custom-env.sh",
-    "postCreateCommand": "for file in .vscode/*.sample; do cp \"$file\" \"${file%.sample}\"; done && cd packages && yarn && yarn dlx @yarnpkg/sdks vscode",
+    "postCreateCommand": "bash /root/scripts/post-create.sh",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.13
+      - PSIBASE_CONTRIBUTOR_VERSION=0.14
     volumes:
       - type: volume
         source: psibase-contributor

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   psibase:
     image: ghcr.io/gofractally/psibase-contributor:073ffc7576039990f47c4389c1258b5033190d60
@@ -20,6 +19,9 @@ services:
       - type: bind
         source: ../local-certs
         target: /root/certs
+      - type: bind
+        source: ../scripts
+        target: /root/scripts
     command: sleep infinity
   mkcert:
     image: vishnunair/docker-mkcert:latest

--- a/scripts/post-create.sh
+++ b/scripts/post-create.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Copy sample VSCode configuration files
+for file in /root/psibase/.vscode/*.sample; do
+    cp "$file" "${file%.sample}"
+done
+
+# Install dependencies and configure VSCode SDKs
+cd packages
+yarn
+yarn dlx @yarnpkg/sdks vscode
+
+# Symlink .clangd file to workspace root
+ln -s /root/psibase/.vscode/.clangd /root/psibase/.clangd


### PR DESCRIPTION
The old C++ extension is being locked down by microsoft, can't be used in editors outside vanilla vscode ([Source](https://devclass.com/2025/04/08/vs-code-extension-marketplace-wars-cursor-users-hit-roadblocks/)).

