### PR TITLE
Install Yarn PnP editor SDKs in onCreateCommand

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.10
+
+- Install [Yarn PnP editor SDKs for VSCode](https://yarnpkg.com/getting-started/editor-sdks) in devcontainer `onCreateCommand` to restore VSCode DX
+
 # 0.9
 
 * [Switch rust-tools to 1.86.0 to support async-graphql@7.0.17](https://github.com/gofractally/image-builders/pull/69)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,6 +6,7 @@
     "workspaceFolder": "/root/psibase",
 
     "initializeCommand": "bash .devcontainer/custom-env.sh",
+    "onCreateCommand": "cd services && yarn && yarn dlx @yarnpkg/sdks vscode",
     "postCreateCommand": "for file in .vscode/*.sample; do cp \"$file\" \"${file%.sample}\"; done",
     "customizations": {
         "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.9
+      - PSIBASE_CONTRIBUTOR_VERSION=0.10
     volumes:
       - type: volume
         source: psibase-contributor


### PR DESCRIPTION
When using Yarn PnP, special editor SDKs for TypeScript, Prettier and ESLint are required. This installs them in the devcontainer.json onCreateCommand to ensure they're present and picked up properly by VSCode.

This PR fixes an issue with the previous attempt (#40) reported by @James-Mart in #41.