### PR TITLE
Revert "Install Yarn PnP editor SDKs in onCreateCommand"

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,7 +1,3 @@
-# 0.10
-
-- Install [Yarn PnP editor SDKs for VSCode](https://yarnpkg.com/getting-started/editor-sdks) in devcontainer `onCreateCommand` to restore VSCode DX
-
 # 0.9
 
 * [Switch rust-tools to 1.86.0 to support async-graphql@7.0.17](https://github.com/gofractally/image-builders/pull/69)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,6 @@
     "workspaceFolder": "/root/psibase",
 
     "initializeCommand": "bash .devcontainer/custom-env.sh",
-    "onCreateCommand": "cd services && yarn && yarn dlx @yarnpkg/sdks vscode",
     "postCreateCommand": "for file in .vscode/*.sample; do cp \"$file\" \"${file%.sample}\"; done",
     "customizations": {
         "vscode": {

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.10
+      - PSIBASE_CONTRIBUTOR_VERSION=0.9
     volumes:
       - type: volume
         source: psibase-contributor


### PR DESCRIPTION
This reverts commit 4a6c0e47d6718fd376d9332716b42d17d0a5b077.

```
[2025-07-01T16:35:01.018Z] Start: Run in container: /bin/sh -c cd services && yarn && yarn dlx @yarnpkg/sdks vscode
[2025-07-01T16:35:01.181Z] 
[2025-07-01T16:35:02.346Z] Usage Error: No project found in /root/psibase/services
```

I'll actually test the next attempt before we merge, so I don't need to keep reverting.