### PR TITLE
Update Yarn PnP SDKs path to new packages directory

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.11
+
+- Update install path for [Yarn PnP editor SDKs for VSCode](https://yarnpkg.com/getting-started/editor-sdks) in devcontainer `postCreateCommand` to restore VSCode DX after `services` directory was renamed to `packages`
+
 # 0.10
 
 - Install [Yarn PnP editor SDKs for VSCode](https://yarnpkg.com/getting-started/editor-sdks) in devcontainer `postCreateCommand` to restore VSCode DX

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
     "workspaceFolder": "/root/psibase",
 
     "initializeCommand": "bash .devcontainer/custom-env.sh",
-    "postCreateCommand": "for file in .vscode/*.sample; do cp \"$file\" \"${file%.sample}\"; done && cd services && yarn && yarn dlx @yarnpkg/sdks vscode",
+    "postCreateCommand": "for file in .vscode/*.sample; do cp \"$file\" \"${file%.sample}\"; done && cd packages && yarn && yarn dlx @yarnpkg/sdks vscode",
     "customizations": {
         "vscode": {
             "extensions": [

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.10
+      - PSIBASE_CONTRIBUTOR_VERSION=0.11
     volumes:
       - type: volume
         source: psibase-contributor


### PR DESCRIPTION
Yarn PnP SDKs assumed packages were in the `services` directory. The `services` directory has since been renamed to `packages`. This updates the installation path for Yarn PnP SDKs.