### PR TITLE
support adding agent-config repo

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.16
+- [Support an external agent-config repo](https://github.com/gofractally/psibase-contributor/pull/49)
+
 # 0.15
 - [Add clangd-18](https://github.com/gofractally/image-builders/pull/73)
 - [Update cargo-generate to latest: 0.23.5](https://github.com/gofractally/image-builders/pull/75)

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,38 +1,33 @@
 {
     "name": "${localWorkspaceFolderBasename}",
-
-    "dockerComposeFile": ["docker-compose.yml"],
+    "dockerComposeFile": [
+        "docker-compose.yml"
+    ],
     "service": "psibase",
     "workspaceFolder": "/root/psibase",
-
     "initializeCommand": "bash .devcontainer/custom-env.sh",
-    "postCreateCommand": "bash /root/psibase/.vscode/scripts/env-setup.sh",
+    "postCreateCommand": "bash /root/init-agent-config.sh && bash /root/psibase/.vscode/scripts/env-setup.sh",
     "customizations": {
         "vscode": {
             "extensions": [
                 // build
                 "actboy168.tasks",
                 "rioj7.command-variable",
-
                 // web
                 "arcanis.vscode-zipfs",
                 "bradlc.vscode-tailwindcss",
                 "dbaeumer.vscode-eslint",
                 "esbenp.prettier-vscode",
-
                 // cpp
                 "llvm-vs-code-extensions.vscode-clangd",
                 "tdennis4496.cmantic",
-
                 // rust
                 "fill-labs.dependi",
                 "tamasfe.even-better-toml",
                 "rust-lang.rust-analyzer",
                 "vadimcn.vscode-lldb",
-
                 // wasm
                 "bytecodealliance.wit-idl",
-
                 // misc
                 "bierner.markdown-mermaid",
                 "eamodio.gitlens",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - path: .env
         required: false
     environment:
+      - AGENT_CONFIG_REPO_URL=
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
@@ -19,6 +20,10 @@ services:
       - type: bind
         source: ../local-certs
         target: /root/certs
+      - type: bind
+        source: ./init-agent-config.sh
+        target: /root/init-agent-config.sh
+        read_only: true
       - type: volume
         source: psibase-contributor-cursor
         target: /root/.cursor

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.15
+      - PSIBASE_CONTRIBUTOR_VERSION=0.16
     volumes:
       - type: volume
         source: psibase-contributor

--- a/.devcontainer/init-agent-config.sh
+++ b/.devcontainer/init-agent-config.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -euo pipefail
+
+# No URL configured; nothing to do.
+if [[ -z "${AGENT_CONFIG_REPO_URL:-}" ]]; then
+    exit 0
+fi
+
+target_dir="/root/agent-config"
+
+# Directory already has contents; do not overwrite.
+if [[ -d "$target_dir" ]] && [[ -n "$(ls -A "$target_dir" 2>/dev/null || true)" ]]; then
+    exit 0
+fi
+
+# Clone target must be a directory, not a file or other node.
+if [[ -e "$target_dir" && ! -d "$target_dir" ]]; then
+    echo "$target_dir exists and is not a directory" >&2
+    exit 1
+fi
+
+# Ensure empty target directory exists for git clone.
+if [[ ! -d "$target_dir" ]]; then
+    mkdir -p "$target_dir"
+fi
+
+# Target directory non-empty; skip clone.
+if [[ -n "$(ls -A "$target_dir" 2>/dev/null || true)" ]]; then
+    exit 0
+fi
+
+git clone "$AGENT_CONFIG_REPO_URL" "$target_dir"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,15 @@ Within the container, you should have some items in the toolbar to help you buil
 
 The first time you use psibase contributor (or after any time your docker volume gets deleted), you will have to configure 
 
+## Optional agent config repo
+
+If you want to reuse agent configurations from another repository:
+
+1. Edit `.devcontainer/docker-compose.yml` and set `AGENT_CONFIG_REPO_URL=https://github.com/owner/repo.git`. The specified repo should can contain `.cursor/`, `.claude/`, etc. configuration directories with rules/skills and other agent configurations.
+2. Restart or reopen the devcontainer. You do not need to rebuild for this feature.
+3. On container start, the repository will be cloned into `/root/agent-config` if not already present.
+4. Then you can symlink your agent config into the root of the `psibase` workspace (`/root/psibase`) or to wherever is needed for your workflow.
+
 # Development data location
 
 All source code and build files are stored within a named docker volume. This data is accessible from within the container or alternatively through Docker Desktop.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The first time you use psibase contributor (or after any time your docker volume
 
 If you want to reuse agent configurations from another repository:
 
-1. Edit `.devcontainer/docker-compose.yml` and set `AGENT_CONFIG_REPO_URL=https://github.com/owner/repo.git`. The specified repo should can contain `.cursor/`, `.claude/`, etc. configuration directories with rules/skills and other agent configurations.
+1. Edit `.devcontainer/docker-compose.yml` and set `AGENT_CONFIG_REPO_URL=https://github.com/owner/repo.git`. The specified repo should contain `.cursor/`, `.claude/`, etc. configuration directories with rules/skills and other agent configurations.
 2. Restart or reopen the devcontainer. You do not need to rebuild for this feature.
 3. On container start, the repository will be cloned into `/root/agent-config` if not already present.
 4. Then you can symlink your agent config into the root of the `psibase` workspace (`/root/psibase`) or to wherever is needed for your workflow.


### PR DESCRIPTION
`psibase-contributor` now supports specifying an external repo that it will automatically clone into `/root/agent-config/` within the container.

Agent configs can then be symlinked into the psibase root workspace if desired.

Additionally, since [this](https://github.com/gofractally/psibase/blob/main/.vscode/scripts/env-setup.sh#L27) landed in `psibase` a `.cursor/` directory in `agent-config/` will **automatically** be symlinked in.