### PR TITLE
change some default env variables config options

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -9,8 +9,7 @@ services:
         required: false
     environment:
       - AGENT_CONFIG_REPO_URL=
-      - VITE_SECURE_LOCAL_DEV=true
-      - VITE_SECURE_PATH_TO_CERTS=/root/certs/
+      - GH_TOKEN=
       # Manually update this whenever changes are made
       - PSIBASE_CONTRIBUTOR_VERSION=0.16
     volumes:


### PR DESCRIPTION
The `VITE` variables were removed from psibase already.
The `GH_TOKEN` variable can be set locally if users want to use the gh cli to make authenticated queries within psibase-contributor