### PR TITLE
Update image

### DIFF
--- a/.devcontainer/CHANGELOG.md
+++ b/.devcontainer/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.17
+- [Add GH CLI](https://github.com/gofractally/image-builders/pull/80)
+- [Add cursor agent CLI](https://github.com/gofractally/image-builders/pull/81)
+- [Environment variable cleanup](https://github.com/gofractally/psibase-contributor/pull/50)
+  - Removes deprecated `VITE` variables
+  - Adds `GH_TOKEN` for use with GH CLI
+
 # 0.16
 - [Support an external agent-config repo](https://github.com/gofractally/psibase-contributor/pull/49)
 

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - VITE_SECURE_LOCAL_DEV=true
       - VITE_SECURE_PATH_TO_CERTS=/root/certs/
       # Manually update this whenever changes are made
-      - PSIBASE_CONTRIBUTOR_VERSION=0.16
+      - PSIBASE_CONTRIBUTOR_VERSION=0.17
     volumes:
       - type: volume
         source: psibase-contributor

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   psibase:
-    image: ghcr.io/gofractally/psibase-contributor:c38d79e2f477c34387ccd824c3e33797691eccb4
+    image: ghcr.io/gofractally/psibase-contributor:5cbe1ff43f23aa256c9e1df0320649adcd5b5d5f
     ports:
       - "8070-8090:8070-8090"
     container_name: psibase-contributor


### PR DESCRIPTION
> **Note**:  Depends on https://github.com/gofractally/psibase-contributor/pull/50


Creates V0.17 of `psibase-contributor`

# 0.17
- [Add GH CLI](https://github.com/gofractally/image-builders/pull/80)
- [Add cursor agent CLI](https://github.com/gofractally/image-builders/pull/81)
- [Environment variable cleanup](https://github.com/gofractally/psibase-contributor/pull/50)
  - Removes deprecated `VITE` variables
  - Adds `GH_TOKEN` for use with GH CLI